### PR TITLE
Feat: Logo 컴포넌트 구현

### DIFF
--- a/components/base/Logo/index.jsx
+++ b/components/base/Logo/index.jsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import styled from '@emotion/styled'
+import PropTypes from 'prop-types'
+import logoNormalFill from 'assets/logo/logo_normal_fill.svg'
+import logoItalicFill from 'assets/logo/logo_italic_fill.svg'
+
+const LogoWrapper = styled.div`
+  width: ${({ width }) => `${width}px`};
+  aspect-ratio: ${({ svgWidth, svgHeight }) => `${svgWidth} / ${svgHeight}`};
+  position: relative;
+  cursor: pointer;
+`
+
+const Logo = ({ width, italic }) => {
+  const { width: svgWidth, height: svgHeight } = italic
+    ? logoItalicFill
+    : logoNormalFill
+
+  return (
+    <Link href="/" passHref>
+      <LogoWrapper width={width} svgWidth={svgWidth} svgHeight={svgHeight}>
+        <Image
+          src={italic ? logoItalicFill.src : logoNormalFill.src}
+          layout="fill"
+          alt="Surf"
+        />
+      </LogoWrapper>
+    </Link>
+  )
+}
+
+Logo.propTypes = {
+  width: PropTypes.number,
+  italic: PropTypes.bool,
+}
+
+Logo.defaultProps = {
+  width: 100,
+  italic: false,
+}
+
+export default Logo

--- a/stories/base/Logo.stories.jsx
+++ b/stories/base/Logo.stories.jsx
@@ -1,0 +1,16 @@
+import Logo from '../../components/base/Logo'
+
+export default {
+  title: 'base/Logo',
+  component: Logo,
+  argTypes: {
+    width: {
+      control: { type: 'range', min: 10, max: 300, step: 10 },
+    },
+    italic: {
+      control: { type: 'boolean' },
+    },
+  },
+}
+
+export const Default = (args) => <Logo {...args} />


### PR DESCRIPTION
- Closes #34 

## 📝 PR 내용

<!-- 수정/추가한 내용 -->
- Logo 컴포넌트 구현
  - props: width(number), italic(bool)
- Logo 컴포넌트 storybook 파일 추가

## 📸 스크린샷

<!-- 필요시 스크린샷 첨부 -->
<img width="316" alt="스크린샷 2021-12-02 오후 2 51 22" src="https://user-images.githubusercontent.com/59479363/144365502-e9e9e871-49b5-4e32-9c50-f07edd3b5d6e.png">

