### PR TITLE
Feat:CategoryCard 컴포넌트 구현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,7 @@
     "arrow-body-style": ["error", "as-needed"],
     "import/no-anonymous-default-export": [2, { "allowObject": true }],
     "import/prefer-default-export": "off",
-    "react/forbid-prop-types": 0
+    "react/forbid-prop-types": 0,
     "jsx-a11y/anchor-is-valid": [
       "error",
       {

--- a/components/domain/CategoryCard/index.jsx
+++ b/components/domain/CategoryCard/index.jsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled'
+import PropTypes from 'prop-types'
+
+const CategoryCard = ({ title, categoryId }) => {
+  const CardContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 90%;
+    height: 100px;
+    padding: 10px 20px;
+    border: 1px solid black;
+    border-radius: 10px;
+  `
+  const ControlBox = styled.div`
+    span {
+      margin-left: 5px;
+      margin-right: 5px;
+      color: #3d7cd0;
+      font-size: 15px;
+      &:hover {
+        text-decoration: underline;
+        cursor: pointer;
+      }
+    }
+  `
+  const Title = styled.div`
+    font-size: 25px;
+    font-weight: bold;
+  `
+
+  const handleEdit = () => {
+    console.log(`show edit modal. CategoryId: ${categoryId}`)
+  }
+  const handleRemove = () => {
+    console.log(`show remove modal CategoryId: ${categoryId}`)
+  }
+  return (
+    <CardContainer>
+      <Title>{title}</Title>
+      <ControlBox>
+        <span onClick={handleEdit}>Edit</span>
+        <span onClick={handleRemove}>Remove</span>
+      </ControlBox>
+    </CardContainer>
+  )
+}
+
+CategoryCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  categoryId: PropTypes.string.isRequired,
+}
+export default CategoryCard

--- a/components/domain/index.js
+++ b/components/domain/index.js
@@ -1,1 +1,2 @@
 export { default as Post } from './Post'
+export { default as CategoryCard } from './CategoryCard'

--- a/stories/domain/CategoryCard.stories.js
+++ b/stories/domain/CategoryCard.stories.js
@@ -1,0 +1,15 @@
+import { CategoryCard } from '../../components/domain'
+
+export default {
+  title: 'Domain/CategoryCard',
+  component: CategoryCard,
+  argTypes: {
+    title: {
+      defaultValue: 'Category title',
+      type: 'text',
+    },
+  },
+}
+export const Default = (args) => {
+  return <CategoryCard {...args} />
+}


### PR DESCRIPTION
* Closes #69

## 📝 PR 내용
* CategoryCard 컴포넌트 구현
* edit, remove 버튼의 경우 관련 모달이 제작되지 않아 handler만 추가하였음
* 너비만 `비율(%)` 사용하여 반응형으로 구현
<!-- 수정/추가한 내용 -->

## 📸 스크린샷
![스크린샷 2021-12-04 오후 3 36 58](https://user-images.githubusercontent.com/19158155/144700349-e908e741-ca15-4032-b318-b375c4c8b060.png)

<!-- 필요시 스크린샷 첨부 -->
