### PR TITLE
Fix: 이름수정 useUser -> useGetUser

### DIFF
--- a/utils/apis/user/useGetUser.js
+++ b/utils/apis/user/useGetUser.js
@@ -1,7 +1,7 @@
 import useSWR from 'swr'
 import fetcher from 'utils/apis/fetcher'
 
-const useUser = (userId) => {
+const useGetUser = (userId) => {
   const { data, error } = useSWR(`/users/${userId}`, fetcher)
 
   return {
@@ -11,4 +11,4 @@ const useUser = (userId) => {
   }
 }
 
-export default useUser
+export default useGetUser


### PR DESCRIPTION
- Closes #193

## 📝 PR 내용
export default 분기를 useGetUser로 했는데 export 시에는 useUser로 넣은 상태였음. 수정!
<!-- 수정/추가한 내용 -->

## 📸 스크린샷

<!-- 필요시 스크린샷 첨부 -->
