### PR TITLE
Refactor: base 컴포넌트 일부 수정

### DIFF
--- a/components/base/Dropdown/index.jsx
+++ b/components/base/Dropdown/index.jsx
@@ -3,18 +3,6 @@ import PropTypes from 'prop-types'
 import { IoMdArrowDropdown, IoMdArrowDropup } from 'react-icons/io'
 import * as Style from './style'
 
-/*
-  category data 형태
-  {
-    "categoryId":Long,
-    "name":String,
-    "isPublic":Boolean,
-    "colorCode":String
-	},
-
-
-*/
-
 const Dropdown = ({
   data = [],
   width,
@@ -98,6 +86,7 @@ const Dropdown = ({
 Dropdown.propTypes = {
   data: PropTypes.array.isRequired,
   width: PropTypes.number,
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   fontSize: PropTypes.number,
   border: PropTypes.bool,
   isObj: PropTypes.bool.isRequired,
@@ -106,6 +95,7 @@ Dropdown.propTypes = {
 
 Dropdown.defaultProps = {
   width: 100,
+  height: 30,
   fontSize: 16,
   border: true,
   isNew: false,

--- a/components/base/Input/index.jsx
+++ b/components/base/Input/index.jsx
@@ -4,7 +4,17 @@ import theme from 'styles/theme'
 
 const Input = forwardRef(
   (
-    { width, height, validate, fontSize, placeholder, type, name, ...props },
+    {
+      width,
+      height,
+      validate,
+      fontSize,
+      placeholder,
+      type,
+      maxLength,
+      name,
+      ...props
+    },
     ref,
   ) => {
     const inputStyle = {
@@ -29,6 +39,7 @@ const Input = forwardRef(
         placeholder={placeholder}
         type={type}
         name={name}
+        maxLength={maxLength}
         {...props}
       />
     )
@@ -40,6 +51,7 @@ Input.propTypes = {
   fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   placeholder: PropTypes.string,
   type: PropTypes.string,
+  maxLength: PropTypes.number,
 }
 Input.defaultProps = {
   width: 190,
@@ -47,6 +59,7 @@ Input.defaultProps = {
   fontSize: 16,
   placeholder: 'input text',
   type: 'text',
+  maxLength: 999,
 }
 
 Input.displayName = 'Input'

--- a/components/base/Toggle/index.jsx
+++ b/components/base/Toggle/index.jsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { useToggle } from 'hooks'
 import { forwardRef } from 'react'
+import PropTypes from 'prop-types'
 
 const ToggleContainer = styled.label`
   display: inline-block;
@@ -53,28 +54,38 @@ const ToggleSwitch = styled.div`
   }
 `
 
-const Toggle = forwardRef(
-  ({ isToggle = false, disabled, onChange, ...props }, ref) => {
-    const [checked, onToggle] = useToggle(isToggle)
-    const handleChange = (e) => {
-      onToggle()
-      // eslint-disable-next-line no-unused-expressions
-      onChange && onChange(e)
-    }
+const Toggle = forwardRef(({ isToggle, disabled, onChange, ...props }, ref) => {
+  const [checked, onToggle] = useToggle({ initialState: isToggle })
+  const handleChange = (e) => {
+    onToggle()
+    // eslint-disable-next-line no-unused-expressions
+    onChange && onChange(e)
+  }
 
-    return (
-      <ToggleContainer {...props}>
-        <ToggleInput
-          type="checkbox"
-          checked={checked}
-          disabled={disabled}
-          onChange={handleChange}
-          ref={ref}
-        />
-        <ToggleSwitch />
-      </ToggleContainer>
-    )
-  },
-)
+  return (
+    <ToggleContainer {...props}>
+      <ToggleInput
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={handleChange}
+        ref={ref}
+      />
+      <ToggleSwitch />
+    </ToggleContainer>
+  )
+})
+
 Toggle.displayName = 'Toggle'
+
+Toggle.propTypes = {
+  isToggle: PropTypes.bool,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+}
+
+Toggle.defaultProps = {
+  isToggle: false,
+  disabled: false,
+}
 export default Toggle


### PR DESCRIPTION
- Closes #221
- `dropdown` height props 추가
  - 기본 30으로 넣되, border: none인 상태에선 영향 없음
 - `Input` 컴포넌트 maxLength 추가
   - surf category 최대 30자 제한
 - `Toggle` 컴포넌트 propTypes, defaultProps 추가 
## 📝 PR 내용

<!-- 수정/추가한 내용 -->

## 📸 스크린샷

<!-- 필요시 스크린샷 첨부 -->
