### PR TITLE
Refactor: Explore 페이지 무한 스크롤 완성

### DIFF
--- a/components/base/Loading/index.jsx
+++ b/components/base/Loading/index.jsx
@@ -27,31 +27,43 @@ const LoadingWrapper = styled.div`
   z-index: 1000;
 `
 
-const Loading = ({ loading, size, blur }) => {
+const Loading = ({ loading, setLoading, size, blur }) => {
   useEffect(() => {
     document.body.style.overflow = loading ? 'hidden' : 'unset'
   }, [loading])
 
+  useEffect(() => {
+    if (loading && setLoading) {
+      setTimeout(() => {
+        setLoading(false)
+      }, 500)
+    }
+  }, [loading])
+
   return (
-    <LoadingWrapper blur={blur}>
-      <Lottie
-        options={defaultOptions}
-        width={size}
-        height={size}
-        isClickToPauseDisabled
-      />
-    </LoadingWrapper>
+    loading && (
+      <LoadingWrapper blur={blur}>
+        <Lottie
+          options={defaultOptions}
+          width={size}
+          height={size}
+          isClickToPauseDisabled
+        />
+      </LoadingWrapper>
+    )
   )
 }
 
 Loading.propTypes = {
   loading: PropTypes.bool,
+  setLoading: PropTypes.func,
   size: PropTypes.number,
   blur: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 Loading.defaultProps = {
   loading: false,
+  setLoading: () => {},
   size: 220,
   blur: 10,
 }

--- a/pages/explore/index.jsx
+++ b/pages/explore/index.jsx
@@ -1,25 +1,27 @@
 import styled from '@emotion/styled'
-import { Children, useEffect, useState } from 'react'
+import { Children, useEffect, useState, useRef } from 'react'
 import { Post } from 'components/domain'
 import { useGetRecentPosts } from 'utils/apis/post'
 import { useRouter } from 'next/router'
 import Cookies from 'js-cookie'
+import { Loading } from 'components/base'
 
 const Container = styled.div`
   padding: 0 20px;
 `
 
 const Explore = () => {
+  const postId = useRef(0)
   const router = useRouter()
   const [cursorId, setCursorId] = useState(0)
-  const { data: recentPosts, isLoading } = useGetRecentPosts(cursorId)
+  const { data: recentPosts } = useGetRecentPosts(cursorId)
   const [target, setTarget] = useState(null)
   const [addedPosts, setAddedPosts] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
 
   const handleObserver = async ([entry]) => {
     if (entry.isIntersecting) {
-      const { postId } = recentPosts[recentPosts.length - 1]
-      setCursorId(postId)
+      setCursorId(postId.current)
     }
   }
 
@@ -32,9 +34,12 @@ const Explore = () => {
   useEffect(() => {
     if (recentPosts && addedPosts === []) {
       setAddedPosts(() => [...recentPosts])
+      postId.current = recentPosts[recentPosts.length - 1].postId
     } else if (recentPosts && addedPosts !== []) {
       setAddedPosts(() => [...addedPosts, ...recentPosts])
+      postId.current = recentPosts[recentPosts.length - 1].postId
     }
+    setIsLoading(true)
   }, [recentPosts])
 
   useEffect(() => {
@@ -50,12 +55,10 @@ const Explore = () => {
     return () => observer && observer.disconnect()
   }, [target])
 
-  if (isLoading) {
-    return <div>로딩중...</div>
-  }
-
   return (
     <Container>
+      {/* <Loading loading={isLoading} setLoading={setIsLoading} size={100} /> */}
+      <Loading loading={isLoading} setLoading={setIsLoading} size={100} />
       {Children.toArray(
         addedPosts?.map((post) => (
           <Post


### PR DESCRIPTION
- Closes #267 

## 📝 PR 내용
- Loading 500ms 추가
- Loading 컴포넌트 setLoading props 추가
  - setLoading 안넣을 경우 loading에 따라 컴포넌트가 보였다 사라짐
  - Explore 페이지 무한 스크롤 수정 
<!-- 수정/추가한 내용 -->

## 📸 스크린샷

<!-- 필요시 스크린샷 첨부 -->
